### PR TITLE
FIX: drag animation for android

### DIFF
--- a/apps/next/global.ts
+++ b/apps/next/global.ts
@@ -1,11 +1,11 @@
 export interface Global {
-    self: Global;
-    setImmediate: typeof setTimeout;
+  self: Global;
+  setImmediate: typeof setTimeout;
 }
 
 declare let global: Global;
 if (typeof global.self === "undefined") {
-    global.self = global;
+  global.self = global;
 }
 
 global.setImmediate = setTimeout;

--- a/apps/next/global.ts
+++ b/apps/next/global.ts
@@ -1,0 +1,11 @@
+export interface Global {
+    self: Global;
+    setImmediate: typeof setTimeout;
+}
+
+declare let global: Global;
+if (typeof global.self === "undefined") {
+    global.self = global;
+}
+
+global.setImmediate = setTimeout;

--- a/apps/next/pages/_app.tsx
+++ b/apps/next/pages/_app.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import type { SolitoAppProps } from "solito";
 import "raf/polyfill";
 import { WebNavigation } from "app/navigation/web";
+import "../global";
 
 function MyApp({ Component, pageProps }: SolitoAppProps) {
   return (

--- a/packages/app/features/dashboard/beat/BeatActivities.tsx
+++ b/packages/app/features/dashboard/beat/BeatActivities.tsx
@@ -126,7 +126,7 @@ export function BeatActivity({
     const sellAsset = activity.assets[0]!;
 
     return (
-      <View className="md:flex-row flex-column md:items-center md:flex-wrap">
+      <View className="md:flex-row flex md:items-center md:flex-wrap">
         <LinkWithLabel type="account" id={buyer} />
         <Text className="my-1 md:my-0 text-sm">
           Transfered {activity.sourceAmount}

--- a/packages/app/hooks/useOnAuthRedirect/index.ts
+++ b/packages/app/hooks/useOnAuthRedirect/index.ts
@@ -22,7 +22,6 @@ export function useOnAuthRedirect(): Result {
     });
     const getInitialUrl = async () => {
       const link = await Linking.getInitialURL();
-      console.log(link);
       if (link && link.startsWith(Config.APP_URL)) {
         const path = link.replace(Config.APP_URL, "");
         setInitialPath(path);

--- a/packages/app/provider/navigation/index.tsx
+++ b/packages/app/provider/navigation/index.tsx
@@ -1,4 +1,5 @@
 import { NavigationContainer } from "@react-navigation/native";
+import { tw } from "app/design-system/tailwind";
 import * as Linking from "expo-linking";
 import { ReactNode, useMemo } from "react";
 
@@ -7,6 +8,17 @@ export function NavigationProvider({ children }: { children: ReactNode }) {
     <NavigationContainer
       // TODO: find how to do it right
       // @ts-ignore
+      theme={{
+        dark: false,
+        colors: {
+          primary: tw.color("blue")!,
+          background: tw.color("blue-dark")!,
+          card: tw.color("blue-dark")!,
+          text: tw.color("white")!,
+          border: tw.color("white")!,
+          notification: tw.color("blue-dark")!,
+        },
+      }}
       linking={useMemo(
         () => ({
           prefixes: [Linking.createURL("/")],

--- a/packages/app/provider/playback.tsx
+++ b/packages/app/provider/playback.tsx
@@ -48,6 +48,7 @@ export type PlaybackApi = {
   onPlaybackStatusUpdate: (status: AVPlaybackStatus) => void;
   onReadyForDisplay: () => void;
   onError: (error: string) => void;
+  resetPlayer: () => void;
 };
 
 export const PlaybackContext = createContext<PlaybackApi>({
@@ -73,6 +74,7 @@ export const PlaybackContext = createContext<PlaybackApi>({
   onPlaybackStatusUpdate: (_) => {},
   onReadyForDisplay: () => {},
   onError: () => {},
+  resetPlayer: () => {},
 });
 
 export function PlaybackProvider({ children }: { children: React.ReactNode }) {
@@ -95,8 +97,8 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
   >();
 
   const resetPlayer = useCallback(() => {
-    setPlaybackState("ERROR");
-    reportError(Error("Couldn't play that beat. Try Again!"));
+    setPlayback(null);
+    setPlaybackState("IDLE");
     setEntry(null);
     setPlaybackUri("");
     setPlayingHistory([]);
@@ -142,6 +144,8 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
         }
         const id = setTimeout(() => {
           if (fallback) {
+            setPlaybackState("ERROR");
+            reportError(Error("Couldn't play that beat. Try Again!"));
             resetPlayer();
           } else {
             setPlaybackState("FALLBACK");
@@ -305,6 +309,8 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
         clearTimeout(timeoutId);
       }
       if (playbackState === "FALLBACK" || !entry) {
+        setPlaybackState("ERROR");
+        reportError(Error("Couldn't play that beat. Try Again!"));
         resetPlayer();
       } else {
         setPlaybackState("FALLBACK");
@@ -350,6 +356,7 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
       onPlaybackStatusUpdate,
       onReadyForDisplay,
       onError,
+      resetPlayer,
     }),
     [
       playback,
@@ -374,6 +381,7 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
       onPlaybackStatusUpdate,
       onReadyForDisplay,
       onError,
+      resetPlayer,
     ]
   );
 

--- a/packages/app/ui/VideoPlayer.tsx
+++ b/packages/app/ui/VideoPlayer.tsx
@@ -31,9 +31,9 @@ export function VideoPlayer({ width, height, style }: Props) {
     // we need to provide correct uri only for web
     // on native we can change uri using loadAsync
     if (Platform.OS === "web" && entry) {
-      return playbackUri;
+      return { uri: playbackUri };
     }
-    return "";
+    return undefined;
   };
 
   useEffect(() => {
@@ -59,9 +59,7 @@ export function VideoPlayer({ width, height, style }: Props) {
       ]}
     >
       <Video
-        source={{
-          uri: getVideoUri(),
-        }}
+        source={getVideoUri()}
         ref={(ref) => {
           if (ref && !playback) {
             setPlayback(ref);

--- a/packages/app/ui/VideoPlayer.tsx
+++ b/packages/app/ui/VideoPlayer.tsx
@@ -24,6 +24,7 @@ export function VideoPlayer({ width, height, style }: Props) {
     playbackState,
     onPlaybackStatusUpdate,
     onError,
+    resetPlayer,
   } = usePlayback();
 
   const getVideoUri = () => {
@@ -34,6 +35,13 @@ export function VideoPlayer({ width, height, style }: Props) {
     }
     return "";
   };
+
+  useEffect(() => {
+    return () => {
+      // resets player when component is unmounted
+      resetPlayer();
+    };
+  }, []);
 
   useEffect(() => {
     // play the last played entry

--- a/packages/app/ui/navigation/mobileTabBarWrapper.tsx
+++ b/packages/app/ui/navigation/mobileTabBarWrapper.tsx
@@ -15,7 +15,7 @@ import {
   GestureDetector,
   Gesture,
 } from "react-native-gesture-handler";
-import { Dimensions } from "react-native";
+import { Dimensions, Platform } from "react-native";
 import { useSafeArea } from "app/provider/safe-area/useSafeArea";
 import { tw } from "app/design-system/tailwind";
 import { usePlayback } from "app/hooks/usePlayback";
@@ -46,6 +46,7 @@ export function MobileTabBarWrapper() {
   const gestureHandler = useMemo(
     () =>
       Gesture.Pan()
+        .enabled(Platform.OS !== "web")
         .onStart((_) => {
           dragStart.value = y.value;
         })

--- a/packages/app/ui/navigation/mobileTabBarWrapper.tsx
+++ b/packages/app/ui/navigation/mobileTabBarWrapper.tsx
@@ -1,85 +1,102 @@
-import { View } from "app/design-system";
 import DashboardTabBar from "app/ui/navigation/dashboardTabBar";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { MiniPlayerBar } from "app/features/player/miniPlayerBar";
 import { FullScreenPlayer } from "app/features/player/fullScreenPlayer";
 import Animated, {
   useSharedValue,
-  useAnimatedGestureHandler,
   useAnimatedStyle,
   interpolate,
   Extrapolation,
-  withSpring,
+  withDecay,
+  withTiming,
 } from "react-native-reanimated";
 import {
-  PanGestureHandler,
   GestureHandlerRootView,
+  GestureDetector,
+  Gesture,
 } from "react-native-gesture-handler";
 import { Dimensions } from "react-native";
 import { useSafeArea } from "app/provider/safe-area/useSafeArea";
+import { tw } from "app/design-system/tailwind";
+import { usePlayback } from "app/hooks/usePlayback";
+import { View } from "app/design-system";
 
-const springAnimationConfig = {
-  damping: 60,
-  stiffnes: 150,
-  restDisplacementThreshold: 0.1,
-};
-
+const fullAnimationDuration = 400;
 const { height } = Dimensions.get("window");
-const miniPlayerHeight = 40;
-export function MobileTabBarWrapper() {
-  const y = useSharedValue(0);
-  const insets = useSafeArea();
-  const tabBarHeight = useMemo(() => 54 + insets.bottom, [insets]); // 52 + 2 border
-  const maxYTranslation = useMemo(
-    () => height - miniPlayerHeight - tabBarHeight,
-    [tabBarHeight]
-  );
 
-  const gestureHandler = useAnimatedGestureHandler({
-    onStart: (_, ctx: { startX: number }) => {
-      ctx.startX = y.value;
-    },
-    onActive: (event, ctx: { startX: number }) => {
-      y.value = Math.max(
-        -maxYTranslation,
-        Math.min(0, ctx.startX + event.translationY)
-      );
-    },
-    onEnd: (event) => {
-      const translationWithVelocity = y.value + event.velocityY;
-      const animateTo =
-        translationWithVelocity < -maxYTranslation / 2 ? -maxYTranslation : 0;
-      y.value = withSpring(animateTo, springAnimationConfig);
-    },
-  });
+export function MobileTabBarWrapper() {
+  const insets = useSafeArea();
+  const { playbackState } = usePlayback();
+
+  const tabBarHeight = useMemo(() => {
+    let height = 54 + insets.bottom;
+    if (playbackState !== "IDLE" && playbackState !== "ERROR") {
+      height = height + 40;
+    }
+    return height;
+  }, [insets, playbackState]); // 52 + 2 border + 40 miniplayer
+  const maxHeight = useMemo(() => height + insets.top, [insets]);
+  const y = useSharedValue(tabBarHeight);
+  const dragStart = useSharedValue(tabBarHeight);
+
+  useEffect(() => {
+    y.value = tabBarHeight;
+  }, [tabBarHeight]);
+
+  const gestureHandler = useMemo(
+    () =>
+      Gesture.Pan()
+        .onStart((_) => {
+          dragStart.value = y.value;
+        })
+        .onUpdate((event) => {
+          y.value = Math.min(
+            maxHeight,
+            Math.max(tabBarHeight, dragStart.value - event.translationY)
+          );
+        })
+        .onEnd((event) => {
+          const minVelocity =
+            (maxHeight - tabBarHeight) / (fullAnimationDuration / 1000);
+          const threshold = (maxHeight - tabBarHeight) / 2;
+          let velocity = y.value > threshold ? minVelocity : -minVelocity;
+          if (event.velocityY > 0) {
+            velocity = Math.min(-minVelocity, -event.velocityY);
+          } else if (event.velocityY < 0) {
+            velocity = Math.max(minVelocity, -event.velocityY);
+          }
+          y.value = withDecay({
+            velocity,
+            deceleration: 1,
+            clamp: [tabBarHeight, maxHeight],
+          });
+        }),
+    [tabBarHeight, maxHeight]
+  );
 
   const draggableStyle = useAnimatedStyle(() => {
     return {
-      transform: [
-        {
-          translateY: y.value,
-        },
-      ],
+      height: y.value,
     };
   });
 
   const playerBarStyle = useAnimatedStyle(() => {
     const opacity = interpolate(
       y.value,
-      [0, -maxYTranslation / 3],
+      [tabBarHeight, maxHeight / 3],
       [1, 0],
       Extrapolation.CLAMP
     );
     return {
       opacity,
-      zIndex: y.value > -maxYTranslation ? 10 : 1,
+      zIndex: y.value === tabBarHeight ? 10 : -1,
     };
-  });
+  }, [tabBarHeight, maxHeight]);
 
   const tabBarStyle = useAnimatedStyle(() => {
     const translation = interpolate(
       y.value,
-      [0, -maxYTranslation],
+      [tabBarHeight, maxHeight],
       [0, tabBarHeight],
       Extrapolation.CLAMP
     );
@@ -90,34 +107,39 @@ export function MobileTabBarWrapper() {
         },
       ],
     };
-  });
+  }, [tabBarHeight, maxHeight]);
 
   const fullScreenPlayerStyle = useAnimatedStyle(() => {
     const opacity = interpolate(
       y.value,
-      [0, -maxYTranslation / 5],
+      [tabBarHeight, maxHeight / 3],
       [0, 1],
       Extrapolation.CLAMP
     );
     return {
       opacity,
-      zIndex: y.value < -maxYTranslation ? 10 : 1,
+      zIndex: y.value === maxHeight ? 10 : 1,
     };
-  });
+  }, [tabBarHeight, maxHeight]);
 
   const onExpand = useCallback(() => {
-    y.value = withSpring(-maxYTranslation, springAnimationConfig);
-  }, [y, maxYTranslation]);
+    y.value = withTiming(maxHeight, { duration: fullAnimationDuration });
+  }, [y, maxHeight]);
 
   const onHide = useCallback(() => {
-    y.value = withSpring(0, springAnimationConfig);
-  }, [y]);
+    y.value = withTiming(tabBarHeight, { duration: fullAnimationDuration });
+  }, [y, tabBarHeight]);
 
   return (
     <GestureHandlerRootView>
-      <View className="flex bg-blue-dark z-10" style={{ elevation: 100 }}>
-        <PanGestureHandler onGestureEvent={gestureHandler}>
-          <Animated.View style={draggableStyle}>
+      <GestureDetector gesture={gestureHandler}>
+        <Animated.View
+          style={[
+            tw.style("flex bg-blue-dark justify-between"),
+            draggableStyle,
+          ]}
+        >
+          <View>
             <MiniPlayerBar
               onTogglePress={onExpand}
               animatedStyle={playerBarStyle}
@@ -126,12 +148,13 @@ export function MobileTabBarWrapper() {
               onTogglePress={onHide}
               animatedStyle={fullScreenPlayerStyle}
             />
+          </View>
+
+          <Animated.View style={[{ zIndex: 10 }, tabBarStyle]}>
+            <DashboardTabBar />
           </Animated.View>
-        </PanGestureHandler>
-        <Animated.View style={[{ zIndex: 10 }, tabBarStyle]}>
-          <DashboardTabBar />
         </Animated.View>
-      </View>
+      </GestureDetector>
     </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION
We had the following issues on Android:
```
1. it's not possible to interact with the beat duration slider
2. it's not possible to scroll the `Liked by` list
3. it's not possible to hide the player by dragging ( you can do it only by tapping the button)
```

I fixed only issue no. 3, by refactoring the animation a little bit (animating `height` instead of `transform`). I've also used the new `react-native-gesture-handler` API (v2) and added a playback state reset on unmount. 

Issues 1, and 2 remained unfixed, however, thanks to refactoring I found a workaround we can use. 

We can fix issue 1 by implementing our own slider using `react-native-gesture-handler`. The currently used slider is not receiving any touch events and that's the reason why it's not working. However, It will receive them if we implement it using `react-native-gesture-handler` (I was testing it). The good thing about implementing our own slider is the possibility to customize it. The currently used slider is not open for big customization of the UI.

Issue no. 2 we can fix using gesture-handler as well and implementing our own horizontal list.

I think we should move fixes of issues 1 and 2 after the release, as they might be time-consuming. What do you think @alejomendoza ?