### PR TITLE
FIX: mobile web overflow

### DIFF
--- a/packages/app/features/dashboard/chart/index.tsx
+++ b/packages/app/features/dashboard/chart/index.tsx
@@ -18,6 +18,7 @@ export function ChartScreen() {
       <FlatList
         data={data}
         keyExtractor={(item) => item.id!}
+        showsVerticalScrollIndicator={false}
         renderItem={({ item, index }) => (
           <BeatListEntry
             entry={item}

--- a/packages/app/features/dashboard/search/search-result-lists/index.tsx
+++ b/packages/app/features/dashboard/search/search-result-lists/index.tsx
@@ -39,6 +39,7 @@ export function SearchResultList<T>({
       ListEmptyComponent={
         <EmptyListIndicator visible={!loading} text={emptyListText} />
       }
+      showsVerticalScrollIndicator={false}
     />
   );
 }

--- a/packages/app/hooks/useWindowSize.ts
+++ b/packages/app/hooks/useWindowSize.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+type Result = {
+  windowHeight: number;
+  mobileView: boolean;
+};
+
+const WIDTH_BREAKPOINT = 640;
+export function useWindowSize(): Result {
+  const [windowHeight, setWindowHeight] = useState<number>(window.innerHeight);
+  const [mobileView, setMobileView] = useState<boolean>(
+    window.innerWidth < WIDTH_BREAKPOINT
+  );
+
+  useEffect(() => {
+    window.addEventListener("resize", () => {
+      console.log(window.innerHeight);
+      setWindowHeight(window.innerHeight);
+      setMobileView(window.innerWidth < WIDTH_BREAKPOINT);
+    });
+
+    return () => {
+      window.removeEventListener("resize", () => {
+        console.log(window.innerHeight);
+        setWindowHeight(window.innerHeight);
+      });
+    };
+  }, [setWindowHeight]);
+
+  return {
+    windowHeight,
+    mobileView,
+  };
+}

--- a/packages/app/hooks/useWindowSize.ts
+++ b/packages/app/hooks/useWindowSize.ts
@@ -21,6 +21,7 @@ export function useWindowSize(): Result {
     return () => {
       window.removeEventListener("resize", () => {
         setWindowHeight(window.innerHeight);
+        setMobileView(window.innerWidth < WIDTH_BREAKPOINT);
       });
     };
   }, [setWindowHeight]);

--- a/packages/app/hooks/useWindowSize.ts
+++ b/packages/app/hooks/useWindowSize.ts
@@ -14,14 +14,12 @@ export function useWindowSize(): Result {
 
   useEffect(() => {
     window.addEventListener("resize", () => {
-      console.log(window.innerHeight);
       setWindowHeight(window.innerHeight);
       setMobileView(window.innerWidth < WIDTH_BREAKPOINT);
     });
 
     return () => {
       window.removeEventListener("resize", () => {
-        console.log(window.innerHeight);
         setWindowHeight(window.innerHeight);
       });
     };

--- a/packages/app/ui/navigation/dashboardNavigation.tsx
+++ b/packages/app/ui/navigation/dashboardNavigation.tsx
@@ -1,14 +1,13 @@
 import { View } from "app/design-system";
 import Navbar from "app/ui/navbar";
-import { tw } from "app/design-system/tailwind";
 import DashboardTabBar from "app/ui/navigation/dashboardTabBar";
-import React from "react";
+import React, { useMemo } from "react";
 import { PlayerBar } from "app/features/player/playerBar";
 import { MobileTabBarWrapper } from "./mobileTabBarWrapper";
 import { useRecoilValue } from "recoil";
 import { userAtom } from "app/state/user";
-import { useSx } from "dripsy";
 import { useNextRouter } from "solito/build/router/use-next-router";
+import { useWindowSize } from "app/hooks/useWindowSize";
 
 export function DashboardNavigation({
   children,
@@ -17,26 +16,23 @@ export function DashboardNavigation({
 }) {
   const router = useNextRouter();
   const route = router?.route || "";
-  const currentTabName = route.split("/").at(-1) || "";
-
-  useSx();
+  const currentTabName = useMemo(() => route.split("/").at(-1) || "", [route]);
+  const { windowHeight, mobileView } = useWindowSize();
   const user = useRecoilValue(userAtom);
   return (
     <View
-      className="flex flex-1 bg-blue-dark overflow-hidden"
-      sx={{ maxHeight: "100vh" }}
+      className="flex bg-blue-dark overflow-hidden"
+      sx={{ height: windowHeight }}
     >
-      {tw.prefixMatch("sm") && <Navbar />}
+      {!mobileView && <Navbar />}
       <View className="flex flex-row flex-1">
-        {!!user && tw.prefixMatch("sm") && (
+        {!!user && !mobileView && (
           <DashboardTabBar currentTabName={currentTabName} column />
         )}
         {children}
       </View>
-      {tw.prefixMatch("sm") && <PlayerBar />}
-      {!tw.prefixMatch("sm") && (
-        <MobileTabBarWrapper currentTabName={currentTabName} />
-      )}
+      {!mobileView && <PlayerBar />}
+      {mobileView && <MobileTabBarWrapper currentTabName={currentTabName} />}
     </View>
   );
 }


### PR DESCRIPTION
There are some limitations to using viewport height on mobile web browsers (https://stackoverflow.com/questions/52848856/100vh-height-when-address-bar-is-shown-chrome-mobile).
To work around them I wrote our custom hook `useWindowSize` that listens to window size changes and triggers re-renders if necessary. Test it to check if everything is correct.