### PR TITLE
FIX: Profile Picture Validation

### DIFF
--- a/packages/app/hooks/usePickMedia.ts
+++ b/packages/app/hooks/usePickMedia.ts
@@ -21,6 +21,7 @@ export default function usePickMedia(
   const [url, setUrl] = useState<string>("");
 
   const pickMedia = async () => {
+    setError(null);
     let result: MediaFileInfo;
     if (type === "image") {
       const file = await launchImageLibraryAsync({

--- a/packages/app/validation/index.tsx
+++ b/packages/app/validation/index.tsx
@@ -75,11 +75,14 @@ export const withdrawFormSchema: (
   });
 };
 
+const ASPECT_RATIO_MIN = 0.99;
+const ASPECT_RATIO_MAX = 1.01;
 const validateImgSquare = (image: MediaFileInfo) => {
   if (!image.image) {
     return "File is not an image!";
   }
-  if (image.height !== image.width) {
+  const aspectRatio = image.width / image.height;
+  if (aspectRatio < ASPECT_RATIO_MIN || aspectRatio > ASPECT_RATIO_MAX) {
     return "Only square images supported!";
   }
   return null;


### PR DESCRIPTION
Images picked by the Image picker on IOS are not perfectly square, even though they should be. The difference is usually just a few pixels, but that's enough for our previous validation to throw an error. I've changed validation so it now accepts the aspect ratio between [0.99, 1.01]